### PR TITLE
Add audience/user management APIs

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -7,7 +7,7 @@
     "status": "Active",
     "releases": [
         {
-            "tagName": "v1.0.1",
+            "tagName": "v1.0.2",
             "products": [
                 "MI 4.3.0"
             ],

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 | Connector Version | Supported WSO2 MI Version |
 |-------------------|---------------------------|
-| 1.0.1             | MI 4.3.0                  |
+| 1.0.2             | MI 4.3.0                  |
 
 
 ## Documentation

--- a/gen_resources/config_fb.json
+++ b/gen_resources/config_fb.json
@@ -9,7 +9,7 @@
       "project": {
         "groupId": "org.wso2.carbon.esb.connector",
         "artifactId": "facebook.ads",
-        "version": "1.0.1-SNAPSHOT"
+        "version": "1.0.2-SNAPSHOT"
       },
       "iconFolderPath": "",
       "mappers": {

--- a/gen_resources/facebook_ads_open_api.yaml
+++ b/gen_resources/facebook_ads_open_api.yaml
@@ -22,7 +22,7 @@ security:
   - ApiKeyAuth: [ ]
 paths:
   /act_{ad_account_id}/adcreatives:
-    get:
+    get: 
       summary: Retrieve a list of ad creatives.
       operationId: Get Ad Creatives
       responses:

--- a/gen_resources/facebook_ads_open_api.yaml
+++ b/gen_resources/facebook_ads_open_api.yaml
@@ -16,6 +16,8 @@ tags:
     description: A group of ads that share the same daily or lifetime budget, schedule, bid type, bid info, and targeting data.
   - name: Ad
     description: Contains information to display an ad and associate it with an ad set.
+  - name: Custom Audience
+    description: Manage custom audiences for ad targeting.
 security:
   - ApiKeyAuth: [ ]
 paths:
@@ -129,6 +131,57 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CustomAudience'
+  /{custom_audience_id}/users:
+    post:
+      tags:
+        - "Custom Audience"
+      summary: Add users to a custom audience.
+      operationId: Add Users to Custom Audience
+      parameters:
+        - in: path
+          name: custom_audience_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the custom audience.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomAudienceUsersAdd'
+      responses:
+        '200':
+          description: Users added to custom audience successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomAudienceUsersResponse'
+    delete:
+      tags:
+        - "Custom Audience"
+      summary: Remove users from a custom audience.
+      operationId: Remove Users from Custom Audience
+      parameters:
+        - in: path
+          name: custom_audience_id
+          required: true
+          schema:
+            type: string
+          description: The ID of the custom audience.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomAudienceUsersRemove'
+      responses:
+        '200':
+          description: Users removed from custom audience successfully.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CustomAudienceUsersResponse'
   /act_{ad_account_id}/campaigns:
     get:
       tags:
@@ -2366,6 +2419,110 @@ components:
         lifetime_budget:
           type: integer
           description: Lifetime budget
+    # New schema for adding users to a custom audience
+    CustomAudienceUsersAdd:
+      type: object
+      properties:
+        payload:
+          $ref: '#/components/schemas/CustomAudiencePayload'
+        session:
+          $ref: '#/components/schemas/CustomAudienceSession'
+        data_processing_options:
+          type: array
+          items:
+            type: string
+          description: Data processing options.
+        data_processing_options_country:
+          type: integer
+          description: Data processing options country code.
+        data_processing_options_state:
+          type: integer
+          description: Data processing options state code.
+      required:
+        - payload
+    CustomAudienceUsersRemove:
+      type: object
+      properties:
+        payload:
+          $ref: '#/components/schemas/CustomAudiencePayload'
+      required:
+        - payload
+    CustomAudienceUsersReplace:
+      type: object
+      properties:
+        payload:
+          $ref: '#/components/schemas/CustomAudiencePayload'
+        session:
+          $ref: '#/components/schemas/CustomAudienceSession'
+      required:
+        - payload
+        - session
+    CustomAudiencePayload:
+      type: object
+      properties:
+        schema:
+          oneOf:
+            - type: string
+            - type: array
+              items:
+                type: string
+          description: The schema of the user data. Can be a single string or an array of strings for multi-key matching.
+        data:
+          type: array
+          items:
+            type: array
+            items:
+              type: string
+          description: The user data to be added or removed.
+        is_raw:
+          type: boolean
+          description: Indicates if the data is raw.
+        page_ids:
+          type: array
+          items:
+            type: string
+          description: List of page IDs when using PAGEUID.
+      required:
+        - schema
+        - data
+    CustomAudienceSession:
+      type: object
+      properties:
+        session_id:
+          type: integer
+          description: Identifier used to track the session.
+        batch_seq:
+          type: integer
+          description: Sequential number to identify the batch in the current session.
+        last_batch_flag:
+          type: boolean
+          description: Indicates if this is the last batch in the session.
+        estimated_num_total:
+          type: integer
+          description: Estimated total number of users to be uploaded in this session.
+      required:
+        - session_id
+        - batch_seq
+    CustomAudienceUsersResponse:
+      type: object
+      properties:
+        audience_id:
+          type: string
+          description: Audience identifier.
+        session_id:
+          type: integer
+          description: Session ID provided in the request.
+        num_received:
+          type: integer
+          description: Total number of users received in this session so far.
+        num_invalid_entries:
+          type: integer
+          description: Number of entries sent with incorrect hashing or invalid format.
+        invalid_entry_samples:
+          type: array
+          items:
+            type: string
+          description: Up to 100 samples of invalid entries found in the current request.
   securitySchemes:
     ApiKeyAuth:
       type: apiKey

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.wso2.carbon.esb.connector</groupId>
     <artifactId>facebook.ads</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
 
     <name>WSO2 Carbon - Facebook Ads Connector</name>
     <url>http://wso2.org</url>

--- a/src/main/java/org/wso2/carbon/facebook/ads/connector/RestURLBuilder.java
+++ b/src/main/java/org/wso2/carbon/facebook/ads/connector/RestURLBuilder.java
@@ -48,6 +48,7 @@ public class RestURLBuilder extends AbstractConnector {
         put("summary", "summary");
         put("objectCount", "object_count");
         put("adAccountId", "ad_account_id");
+        put("customAudienceId", "custom_audience_id");
         put("campaignId", "campaign_id");
         put("beforeDate", "before_date");
         put("updatedSince", "updated_since");

--- a/src/main/resources/functions/addUsersToAudience.xml
+++ b/src/main/resources/functions/addUsersToAudience.xml
@@ -1,0 +1,60 @@
+<!--
+ ~  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~  WSO2 LLC. licenses this file to you under the Apache License,
+ ~  Version 2.0 (the "License"); you may not use this file except
+ ~  in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing,
+ ~  software distributed under the License is distributed on an
+ ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~  KIND, either express or implied.  See the License for the
+ ~  specific language governing permissions and limitations
+ ~  under the License.
+-->
+
+<!-- Generated on 16-Wed, 10, 2024 19:59:26+0530 -->
+
+<template xmlns="http://ws.apache.org/ns/synapse" name="addUsersToAudience">
+    <!-- Path Parameter List -->
+    <parameter name="customAudienceId" description="The ID of the custom audience."/>
+    <!-- Request Body Parameter List -->
+    <parameter name="properties" description="Custom audience users properties."/>
+    <sequence>
+        <class name="org.wso2.carbon.facebook.ads.connector.RestURLBuilder">
+            <property name="operationPath" value="/{custom_audience_id}/users"/>
+            <property name="pathParameters" value="customAudienceId,"/>
+        </class>
+        <payloadFactory media-type="json" template-type="freemarker">
+            <format><![CDATA[
+${args.arg1}
+            ]]></format>
+            <args>
+                <arg evaluator="xml" expression="$func:properties"/>
+            </args>
+        </payloadFactory>
+        <property name="DISABLE_CHUNKING" scope="axis2" type="STRING" value="true"/>
+        <property name="messageType" value="application/json" scope="axis2"/>
+        <property name="ContentType" value="application/json" scope="axis2"/>
+        <header name="Accept" value="application/json" scope="transport" action="set"/>
+        <call>
+            <endpoint>
+                <http method="POST" uri-template="{uri.var.base}{+uri.var.urlPath}{+uri.var.urlQuery}"/>
+            </endpoint>
+        </call>
+        <!-- Remove custom header information -->
+        <header name="x-business-use-case-usage" scope="transport" action="remove"/>
+        <header name="facebook-api-version" scope="transport" action="remove"/>
+        <header name="Strict-Transport-Security" scope="transport" action="remove"/>
+        <header name="x-fb-request-id" scope="transport" action="remove"/>
+        <header name="x-fb-trace-id" scope="transport" action="remove"/>
+        <header name="x-fb-rev" scope="transport" action="remove"/>
+        <header name="X-FB-Debug" scope="transport" action="remove"/>
+        <header name="x-fb-server-load" scope="transport" action="remove"/>
+        <header name="X-FB-Connection-Quality" scope="transport" action="remove"/>
+        <header name="Alt-Svc" scope="transport" action="remove"/>
+    </sequence>
+</template>

--- a/src/main/resources/functions/component.xml
+++ b/src/main/resources/functions/component.xml
@@ -93,5 +93,13 @@
             <file>updateCustomAudience.xml</file>
             <description>Updates a custom audience.</description>
         </component>
+        <component name="addUsersToAudience">
+            <file>addUsersToAudience.xml</file>
+            <description>Add users to your Custom Audience.</description>
+        </component>
+        <component name="removeUsersFromAudience">
+            <file>removeUsersFromAudience.xml</file>
+            <description>Remove users from your Custom Audience.</description>
+        </component>
     </subComponents>
 </component>

--- a/src/main/resources/functions/removeUsersFromAudience.xml
+++ b/src/main/resources/functions/removeUsersFromAudience.xml
@@ -1,0 +1,60 @@
+<!--
+ ~  Copyright (c) 2024, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~  WSO2 LLC. licenses this file to you under the Apache License,
+ ~  Version 2.0 (the "License"); you may not use this file except
+ ~  in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing,
+ ~  software distributed under the License is distributed on an
+ ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~  KIND, either express or implied.  See the License for the
+ ~  specific language governing permissions and limitations
+ ~  under the License.
+-->
+
+<!-- Generated on 16-Wed, 10, 2024 19:59:26+0530 -->
+
+<template xmlns="http://ws.apache.org/ns/synapse" name="removeUsersFromAudience">
+    <!-- Path Parameter List -->
+    <parameter name="customAudienceId" description="The ID of the custom audience."/>
+    <!-- Request Body Parameter List -->
+    <parameter name="properties" description="Custom audience users properties."/>
+    <sequence>
+        <class name="org.wso2.carbon.facebook.ads.connector.RestURLBuilder">
+            <property name="operationPath" value="/{custom_audience_id}/users"/>
+            <property name="pathParameters" value="customAudienceId,"/>
+        </class>
+        <payloadFactory media-type="json" template-type="freemarker">
+            <format><![CDATA[
+${args.arg1}
+            ]]></format>
+            <args>
+                <arg evaluator="xml" expression="$func:properties"/>
+            </args>
+        </payloadFactory>
+        <property name="DISABLE_CHUNKING" scope="axis2" type="STRING" value="true"/>
+        <property name="messageType" value="application/json" scope="axis2"/>
+        <property name="ContentType" value="application/json" scope="axis2"/>
+        <header name="Accept" value="application/json" scope="transport" action="set"/>
+        <call>
+            <endpoint>
+                <http method="DELETE" uri-template="{uri.var.base}{+uri.var.urlPath}{+uri.var.urlQuery}"/>
+            </endpoint>
+        </call>
+        <!-- Remove custom header information -->
+        <header name="x-business-use-case-usage" scope="transport" action="remove"/>
+        <header name="facebook-api-version" scope="transport" action="remove"/>
+        <header name="Strict-Transport-Security" scope="transport" action="remove"/>
+        <header name="x-fb-request-id" scope="transport" action="remove"/>
+        <header name="x-fb-trace-id" scope="transport" action="remove"/>
+        <header name="x-fb-rev" scope="transport" action="remove"/>
+        <header name="X-FB-Debug" scope="transport" action="remove"/>
+        <header name="x-fb-server-load" scope="transport" action="remove"/>
+        <header name="X-FB-Connection-Quality" scope="transport" action="remove"/>
+        <header name="Alt-Svc" scope="transport" action="remove"/>
+    </sequence>
+</template>

--- a/src/main/resources/uischema/addUsersToAudience.json
+++ b/src/main/resources/uischema/addUsersToAudience.json
@@ -1,0 +1,61 @@
+{
+  "connectorName": "facebookAds",
+  "operationName": "addUsersToAudience",
+  "title": "Add Users To Custom Audience",
+  "help": "This is Add Users to Custom Audience operation.",
+  "elements": [
+    {
+      "type": "attributeGroup",
+      "value": {
+        "groupName": "General",
+        "elements": [
+          {
+            "type": "attribute",
+            "value": {
+              "name": "configRef",
+              "displayName": "Connection",
+              "inputType": "connection",
+              "allowedConnectionTypes": [
+                "facebookAds"
+              ],
+              "defaultType": "connection.facebookAds",
+              "defaultValue": "",
+              "required": "true",
+              "helpTip": "Connection to be used."
+            }
+          },
+          {
+            "type": "attributeGroup",
+            "value": {
+              "groupName": "Parameters",
+              "elements": [
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "customAudienceId",
+                    "displayName": "Custom Audience Id",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "true",
+                    "helpTip": "ID of the custom audience."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "properties",
+                    "displayName": "Properties",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "true",
+                    "helpTip": "Custom audience users properties."
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/src/main/resources/uischema/removeUsersFromAudience.json
+++ b/src/main/resources/uischema/removeUsersFromAudience.json
@@ -1,0 +1,61 @@
+{
+  "connectorName": "facebookAds",
+  "operationName": "removeUsersFromAudience",
+  "title": "Remove Users From Custom Audience",
+  "help": "This is Remove Users from Custom Audience operation.",
+  "elements": [
+    {
+      "type": "attributeGroup",
+      "value": {
+        "groupName": "General",
+        "elements": [
+          {
+            "type": "attribute",
+            "value": {
+              "name": "configRef",
+              "displayName": "Connection",
+              "inputType": "connection",
+              "allowedConnectionTypes": [
+                "facebookAds"
+              ],
+              "defaultType": "connection.facebookAds",
+              "defaultValue": "",
+              "required": "true",
+              "helpTip": "Connection to be used."
+            }
+          },
+          {
+            "type": "attributeGroup",
+            "value": {
+              "groupName": "Parameters",
+              "elements": [
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "customAudienceId",
+                    "displayName": "Custom audience Id",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "true",
+                    "helpTip": "ID of the ad set."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "properties",
+                    "displayName": "Properties",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "true",
+                    "helpTip": "Custom audience users update properties."
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
$title

### Testing

**Steps:**
**1. Create a custom audience**
<img width="450" alt="Screenshot 2024-10-17 at 20 47 22" src="https://github.com/user-attachments/assets/1546da5d-c1c9-42d2-b15e-503972944fdc">

Save the custom audience Id

**2. Add/Remove users (same payload)**

Hash the emails. Python script:
```python
import hashlib

emails = ['user1@example.com', 'user2@example.com']
hashed_emails = [hashlib.sha256(email.strip().lower().encode('utf-8')).hexdigest() for email in emails]
print(hashed_emails)
```
Sample request: 
```json
{
    "properties": {
        "payload": {
            "schema": "EMAIL_SHA256",
            "data": [
                "b36a83701f1c3191e19722d6f90274bc1b5501fe69ebf33313e440fe4b0fe210",
                "2b3b2b9ce842ab8b6a6c614cb1f9604bb8a0d502d1af49c526b72b10894e95b5"
            ]
        }
    }
}
```

UI

<img width="703" alt="Screenshot 2024-10-17 at 21 03 02" src="https://github.com/user-attachments/assets/f78e7edb-17f9-4a72-8806-181d0ec7b2eb">

